### PR TITLE
Create delta firmware for updates to the same image

### DIFF
--- a/scripts/ci_create_firmware.sh
+++ b/scripts/ci_create_firmware.sh
@@ -14,6 +14,7 @@ set -e
 
 [[ -n "$MIX_TARGET" ]] || (echo "MIX_TARGET unset"; exit 1)
 [[ -d "$DEPLOY_PATH" ]] || (echo "DEPLOY_PATH unset or directory doesn't exist"; exit 1)
+[[ -n "$MIX_ENV" ]] || MIX_ENV=dev
 
 FULL_FIRMWARE_FILENAME="nerves_livebook_${MIX_TARGET}.fw"
 FULL_FIRMWARE_PATH="$DEPLOY_PATH/$FULL_FIRMWARE_FILENAME"
@@ -22,7 +23,7 @@ PREVIOUS_FIRMWARE_URL=https://github.com/livebook-dev/nerves_livebook/releases/l
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 # Copy the firmware out of the build directory
-cp _build/*/nerves/images/*.fw "$FULL_FIRMWARE_PATH"
+cp "_build/${MIX_TARGET}_${MIX_ENV}/nerves/images/nerves_livebook.fw" "$FULL_FIRMWARE_PATH"
 
 # Sign the firmware image if there was a key
 if [[ -n "$FW_SIGNING_KEY" ]]; then
@@ -43,6 +44,20 @@ DELTA_FIRMWARE_FILENAME="z${PREVIOUS_FIRMWARE_UUID}_${MIX_TARGET}.fw"
 DELTA_FIRMWARE_PATH="$DEPLOY_PATH/$DELTA_FIRMWARE_FILENAME"
 
 "$SCRIPT_DIR/create_delta_fw.sh" "$PREVIOUS_FIRMWARE_FILENAME" "$FULL_FIRMWARE_PATH" "$DELTA_FIRMWARE_PATH"
+
+echo "Successfully created $DELTA_FIRMWARE_PATH"
+
+# Create a delta firmware update that goes from the current firmware to itself for easier
+# testing. No one would do this for real, but it's super convenient when showing off the
+# capability and it makes it more obvious that there are some parts of the firmware that
+# do not support deltas.
+
+CURRENT_FIRMWARE_UUID=$(fwup -m -i "$FULL_FIRMWARE_PATH" | sed -rn 's/^meta-uuid="([a-f0-9\-]+)"$/\1/p')
+
+DELTA_FIRMWARE_FILENAME="z${CURRENT_FIRMWARE_UUID}_${MIX_TARGET}.fw"
+DELTA_FIRMWARE_PATH="$DEPLOY_PATH/$DELTA_FIRMWARE_FILENAME"
+
+"$SCRIPT_DIR/create_delta_fw.sh" "$FULL_FIRMWARE_PATH" "$FULL_FIRMWARE_PATH" "$DELTA_FIRMWARE_PATH"
 
 echo "Successfully created $DELTA_FIRMWARE_PATH"
 


### PR DESCRIPTION
This is silly in production, but for demonstration, having firmware
updates around that go to the same image that you're using is really
convenient. I.e., you don't have to downgrade to the previous image to
try out the delta firmware update code again.
