### PR TITLE
Save notebooks to /data/livebook

### DIFF
--- a/config/target.exs
+++ b/config/target.exs
@@ -26,7 +26,7 @@ config :livebook, LivebookWeb.Endpoint,
   secret_key_base: "9hHHeOiAA8wrivUfuS//jQMurHxoMYUtF788BQMx2KO7mYUE8rVrGGG09djBNQq7"
 
 config :livebook,
-  root_path: "/data/livebooks"
+  root_path: "/data/livebook"
 
 # Nerves Runtime can enumerate hardware devices and send notifications via
 # SystemRegistry. This slows down startup and not many programs make use of

--- a/lib/nerves_livebook/application.ex
+++ b/lib/nerves_livebook/application.ex
@@ -27,7 +27,7 @@ defmodule NervesLivebook.Application do
   end
 
   defp initialize_data_directory() do
-    destination_dir = "/data/livebooks"
+    destination_dir = "/data/livebook"
     source_dir = Application.app_dir(:nerves_livebook, "priv")
 
     # Best effort create everything

--- a/priv/welcome.livemd
+++ b/priv/welcome.livemd
@@ -36,7 +36,7 @@ re-initialize it in your computer. That will erase them.
 
 If you want to copy a file off the Nerves Livebook image, open up a shell on
 your computer and run `sftp livebook@nerves.local`. The password is `nerves`.
-Once you're logged in, navigate to `/data/livebooks` or where ever you stored
+Once you're logged in, navigate to `/data/livebook` or where ever you stored
 your files and run `get` to copy them off.
 
 ## Limitations


### PR DESCRIPTION
This removes the "s" so that the data directory is the same as the
application name. This also is more consistent with the use of
"Livebook" to refer to the app and "notebook" or "code notebook" to
refer to the files.

This will certainly be an annoying update, but better late than never.
