### PR TITLE
No need to check for empty atoms in Mix.target()

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -37,7 +37,7 @@ config :nerves, source_date_epoch: "1603310828"
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
-if Mix.target() == :host or Mix.target() == :"" do
+if Mix.target() == :host do
   import_config "host.exs"
 else
   import_config "target.exs"


### PR DESCRIPTION
This is fixed in Elixir 1.12 and nerves_livebook only works with Elixir
1.12.
