### PR TITLE
Super easy login

### DIFF
--- a/config/target.exs
+++ b/config/target.exs
@@ -34,7 +34,6 @@ config :nerves, :erlinit,
 # * See https://hexdocs.pm/ssh_subsystem_fwup/readme.html for firmware updates
 
 config :nerves_ssh,
-  user_passwords: [{"livebook", "nerves"}, {"root", "nerves"}],
   daemon_option_overrides: [
     {:pwdfun, &NervesLivebook.ssh_check_pass/2},
     {:auth_method_kb_interactive_data, &NervesLivebook.ssh_show_prompt/3}

--- a/config/target.exs
+++ b/config/target.exs
@@ -36,10 +36,8 @@ config :nerves, :erlinit,
 config :nerves_ssh,
   user_passwords: [{"livebook", "nerves"}, {"root", "nerves"}],
   daemon_option_overrides: [
-    {:auth_method_kb_interactive_data,
-     {'Nerves Livebook',
-      'https://github.com/livebook-dev/nerves_livebook\n\nssh livebook@nerves.local # Use password "nerves"\n',
-      'Password: ', false}}
+    {:pwdfun, &NervesLivebook.ssh_check_pass/2},
+    {:auth_method_kb_interactive_data, &NervesLivebook.ssh_show_prompt/3}
   ]
 
 config :mdns_lite,
@@ -50,7 +48,7 @@ config :mdns_lite,
   dns_bridge_port: 53,
   dns_bridge_recursive: false,
   # Respond to "nerves-1234.local` and "nerves.local"
-  hosts: [:hostname, "nerves"],
+  hosts: [:hostname, "livebook"],
   ttl: 120,
 
   # Advertise the following services over mDNS.

--- a/config/target.exs
+++ b/config/target.exs
@@ -47,7 +47,7 @@ config :mdns_lite,
   dns_bridge_port: 53,
   dns_bridge_recursive: false,
   # Respond to "nerves-1234.local` and "nerves.local"
-  hosts: [:hostname, "livebook"],
+  hosts: [:hostname, "nerves"],
   ttl: 120,
 
   # Advertise the following services over mDNS.

--- a/lib/nerves_livebook.ex
+++ b/lib/nerves_livebook.ex
@@ -54,4 +54,32 @@ defmodule NervesLivebook do
       _ -> Logger.error("Unexpected error setting up Erlang distribution")
     end
   end
+
+  def ssh_check_pass(_username, _password) do
+    # Don't try this at home!
+    true
+  end
+
+  def ssh_show_prompt(_peer, 'livebook', _service) do
+    msg = """
+    https://github.com/livebook-dev/nerves_livebook
+
+    Use password "nerves"
+    """
+
+    {'Nerves Livebook', to_charlist(msg), 'Password: ', false}
+  end
+
+  def ssh_show_prompt(_peer, username, _service) do
+    msg = """
+    https://github.com/livebook-dev/nerves_livebook
+
+    Wrong username, should use username 'livebook' (received #{username})
+
+    ssh #{Node.self()} # Use password "nerves"
+    """
+
+    {'Nerves Livebook', to_charlist(msg), 'Password: ', false}
+  end
+
 end

--- a/lib/nerves_livebook.ex
+++ b/lib/nerves_livebook.ex
@@ -55,31 +55,19 @@ defmodule NervesLivebook do
     end
   end
 
-  def ssh_check_pass(_username, _password) do
-    # Don't try this at home!
-    true
+  def ssh_check_pass(_provided_username, provided_password) do
+    correct_password = Application.get_env(:livebook, :password, "nerves")
+
+    provided_password == to_charlist(correct_password)
   end
 
-  def ssh_show_prompt(_peer, 'livebook', _service) do
+  def ssh_show_prompt(_peer, _username, _service) do
     msg = """
     https://github.com/livebook-dev/nerves_livebook
-
-    Use password "nerves"
-    """
-
-    {'Nerves Livebook', to_charlist(msg), 'Password: ', false}
-  end
-
-  def ssh_show_prompt(_peer, username, _service) do
-    msg = """
-    https://github.com/livebook-dev/nerves_livebook
-
-    Wrong username, should use username 'livebook' (received #{username})
 
     ssh #{Node.self()} # Use password "nerves"
     """
 
     {'Nerves Livebook', to_charlist(msg), 'Password: ', false}
   end
-
 end


### PR DESCRIPTION
When I was at NervesConf I noticed that a few people had trouble realizing that `ssh nerves.local` would not work and instead they needed to do `ssh livebook@nerves.local`. This is an attempt at fixing that (or removing the restriction completely!)

This is probably not quite how we want to do it. But there are two options for improvement and I figured I'd just show them both on one PR.

Set `:pwdfun` to control what the valid passwords are, the simplest implementation of this is to just return `true` (which is currently in this PR), this will allow an ssh connect to succeed with **ANY** username and password combo. Very easy. Also very insecure, but is it that much different than stating the correct username and password at the SSH prompt? Another way to do this would be to allow any username, but only the password "nerves".

The other improvement that could be made (and I think should be) is to warn the user if they are using an incorrect password, along with showing the actual node name instead of a hard-coded `nerves.local`. This is accomplished by passing a function to `:auth_method_kb_interactive_data`.

Here's how that looks (note that nerves-517f.local is my rpi0 hostname, it will be different when you run this):

```
jason@jdesktop ~/d/f/nerves_livebook (frank-main)> ssh nerves.local
Nerves Livebook
https://github.com/livebook-dev/nerves_livebook

Wrong username, should use username 'livebook' (received jason)

ssh livebook@nerves-517f.local # Use password "nerves"

(jason@livebook.local) Password:
```

```
jason@jdesktop ~/d/f/nerves_livebook (easy-login)> ssh nerves@livebook.local
Nerves Livebook
https://github.com/livebook-dev/nerves_livebook

Use password "nerves"

(livebook@livebook.local) Password:
```

If we want to move forward with this approach there's some consistency fixes to do in those messages.