### PR TITLE
Support OTP 25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 defaults: &defaults
   working_directory: /nerves/build
   docker:
-    - image: nervesproject/nerves_system_br:1.18.6
+    - image: nervesproject/nerves_system_br:1.19.0
   environment:
     MIX_ENV: prod
 
 elixir_version: &elixir_version
-  ELIXIR_VERSION: 1.13.4-otp-24
+  ELIXIR_VERSION: 1.13.4-otp-25
 
 install_elixir: &install_elixir
   run:

--- a/mix.exs
+++ b/mix.exs
@@ -105,7 +105,7 @@ defmodule NervesLivebook.MixProject do
 
   defp dialyzer() do
     [
-      flags: [:race_conditions, :unmatched_returns, :error_handling, :underspecs],
+      flags: [:missing_return, :extra_return, :unmatched_returns, :error_handling, :underspecs],
       ignore_warnings: ".dialyzer_ignore.exs"
     ]
   end


### PR DESCRIPTION
* remove deprecated `:race_conditions` dialyzer option
* Add new `:missing_return` and `:extra_return` dialyzer options
* Update Elixir/Erlang CI versions