### PR TITLE
Support LEDs with max_brightness > 1

### DIFF
--- a/lib/nerves_livebook/pattern_led.ex
+++ b/lib/nerves_livebook/pattern_led.ex
@@ -58,11 +58,22 @@ defmodule NervesLivebook.PatternLED do
   end
 
   @doc """
+  Get the maximum brightness for an LED
+  """
+  @spec get_max_brightness(String.t()) :: {:ok, pos_integer()} | {:error, atom()}
+  def get_max_brightness(led) when is_binary(led) do
+    case File.read(["/sys/class/leds/", led, "/max_brightness"]) do
+      {:ok, str} -> {:ok, str |> String.trim() |> String.to_integer()}
+      error -> error
+    end
+  end
+
+  @doc """
   Turn the LED on
   """
-  @spec on() :: String.t()
-  def on() do
-    "1 3600000 1 3600000"
+  @spec on(pos_integer()) :: String.t()
+  def on(brightness) do
+    "#{brightness} 3600000 #{brightness} 3600000"
   end
 
   @doc """
@@ -82,8 +93,8 @@ defmodule NervesLivebook.PatternLED do
     LED is on (default is 0.5)
   * `:off_first` - set to `true` to start in the "off" state, then switch to "on"
   """
-  @spec blink(number(), [blink_option()]) :: String.t()
-  def blink(frequency, opts \\ []) when frequency > 0 do
+  @spec blink(pos_integer(), number(), [blink_option()]) :: String.t()
+  def blink(brightness, frequency, opts \\ []) when frequency > 0 do
     duty_cycle = bound(0, opts[:duty_cycle] || 0.5, 1)
     off_first = opts[:off_first]
 
@@ -91,7 +102,7 @@ defmodule NervesLivebook.PatternLED do
     on_time = round(period_ms * duty_cycle)
     off_time = period_ms - on_time
 
-    on_pattern = "1 #{on_time} 1 0"
+    on_pattern = "#{brightness} #{on_time} #{brightness} 0"
     off_pattern = "0 #{off_time} 0 0"
 
     if off_first do

--- a/test/nerves_livebook/pattern_led_test.exs
+++ b/test/nerves_livebook/pattern_led_test.exs
@@ -3,28 +3,30 @@ defmodule NervesLivebook.PatternLEDTest do
   alias NervesLivebook.PatternLED
 
   test "trivial patterns" do
-    assert "1 3600000 1 3600000" == PatternLED.on()
+    assert "1 3600000 1 3600000" == PatternLED.on(1)
+    assert "255 3600000 255 3600000" == PatternLED.on(255)
     assert "0 3600000 0 3600000" == PatternLED.off()
   end
 
   describe "blink patterns" do
     test "simple blinking" do
-      assert "1 500 1 0 0 500 0 0" == PatternLED.blink(1)
-      assert "1 50 1 0 0 50 0 0" == PatternLED.blink(10)
-      assert "1 167 1 0 0 166 0 0" == PatternLED.blink(3)
+      assert "1 500 1 0 0 500 0 0" == PatternLED.blink(1, 1)
+      assert "255 500 255 0 0 500 0 0" == PatternLED.blink(255, 1)
+      assert "1 50 1 0 0 50 0 0" == PatternLED.blink(1, 10)
+      assert "1 167 1 0 0 166 0 0" == PatternLED.blink(1, 3)
     end
 
     test "duty cycle" do
-      assert "1 250 1 0 0 750 0 0" == PatternLED.blink(1, duty_cycle: 0.25)
+      assert "1 250 1 0 0 750 0 0" == PatternLED.blink(1, 1, duty_cycle: 0.25)
 
       # out of bounds values roughly do what you'd expect
-      assert "1 0 1 0 0 1000 0 0" == PatternLED.blink(1, duty_cycle: -100)
-      assert "1 1000 1 0 0 0 0 0" == PatternLED.blink(1, duty_cycle: 100)
+      assert "1 0 1 0 0 1000 0 0" == PatternLED.blink(1, 1, duty_cycle: -100)
+      assert "1 1000 1 0 0 0 0 0" == PatternLED.blink(1, 1, duty_cycle: 100)
     end
 
     test "blinking but off first" do
-      assert "0 500 0 0 1 500 1 0" == PatternLED.blink(1, off_first: true)
-      assert "0 750 0 0 1 250 1 0" == PatternLED.blink(1, duty_cycle: 0.25, off_first: true)
+      assert "0 500 0 0 1 500 1 0" == PatternLED.blink(1, 1, off_first: true)
+      assert "0 750 0 0 1 250 1 0" == PatternLED.blink(1, 1, duty_cycle: 0.25, off_first: true)
     end
   end
 end


### PR DESCRIPTION
PWM LEDs can support many more levels of brightness so hardcoding the
brightness to 1 ends up making them pretty dim. This changes the code to
get the max_brightness and use it.
