### PR TITLE
Remove host warnings

### DIFF
--- a/config/host.exs
+++ b/config/host.exs
@@ -5,13 +5,3 @@ config :nerves_runtime,
 
 # Configure Nerves runtime dependencies for the host
 config :nerves_runtime, Nerves.Runtime.KV.Mock, %{"nerves_fw_devpath" => "/dev/will_not_work"}
-
-config :vintage_net,
-  resolvconf: "/dev/null",
-  persistence_dir: "./test_tmp/persistence",
-  path: "#{File.cwd!()}/test/fixtures/root/bin"
-
-# Turn off ntp
-config :nerves_time, servers: []
-
-config :mdns_lite, if_monitor: MdnsLite.InetMonitor

--- a/lib/nerves_livebook.ex
+++ b/lib/nerves_livebook.ex
@@ -31,11 +31,15 @@ defmodule NervesLivebook do
   Convenience method for checking internet-connectivity for a Livebook
   """
   @spec check_internet!() :: :ok
-  def check_internet!() do
-    unless target() == :host or VintageNet.get(["connection"]) == :internet,
-      do: raise("Please check that at least one network interface can reach the internet")
+  if Mix.target() == :host do
+    def check_internet!(), do: :ok
+  else
+    def check_internet!() do
+      unless VintageNet.get(["connection"]) == :internet,
+        do: raise("Please check that at least one network interface can reach the internet")
 
-    :ok
+      :ok
+    end
   end
 
   def ssh_check_pass(_provided_username, provided_password) do

--- a/lib/nerves_livebook/ui.ex
+++ b/lib/nerves_livebook/ui.ex
@@ -30,7 +30,7 @@ defmodule NervesLivebook.UI do
     with {:ok, led} <- Keyword.fetch(opts, :led),
          true <- is_binary(led),
          :ok <- PatternLED.initialize_led(led) do
-      setup_led()
+      setup_led(led)
 
       {:ok, led}
     else
@@ -59,9 +59,9 @@ defmodule NervesLivebook.UI do
   end
 
   if Mix.target() == :host do
-    defp setup_led(), do: :ok
+    defp setup_led(_led), do: :ok
   else
-    defp setup_led() do
+    defp setup_led(led) do
       VintageNet.subscribe(["connection"])
       update_led(led, VintageNet.get(["connection"]))
     end

--- a/lib/nerves_livebook/ui.ex
+++ b/lib/nerves_livebook/ui.ex
@@ -30,8 +30,7 @@ defmodule NervesLivebook.UI do
     with {:ok, led} <- Keyword.fetch(opts, :led),
          true <- is_binary(led),
          :ok <- PatternLED.initialize_led(led) do
-      VintageNet.subscribe(["connection"])
-      update_led(led, VintageNet.get(["connection"]))
+      setup_led()
 
       {:ok, led}
     else
@@ -56,6 +55,15 @@ defmodule NervesLivebook.UI do
     else
       {:error, reason} ->
         Logger.info("NervesLivebook failed to set LED '#{led}': #{inspect(reason)}")
+    end
+  end
+
+  if Mix.target() == :host do
+    defp setup_led(), do: :ok
+  else
+    defp setup_led() do
+      VintageNet.subscribe(["connection"])
+      update_led(led, VintageNet.get(["connection"]))
     end
   end
 

--- a/test/nerves_livebook/dependencies_test.exs
+++ b/test/nerves_livebook/dependencies_test.exs
@@ -17,8 +17,11 @@ defmodule NervesLivebook.DependenciesTest do
     assert "circuits_i2c" in names
     assert "circuits_spi" in names
     assert "circuits_uart" in names
-    assert "vintage_net" in names
-    assert "vintage_net_wifi" in names
+
+    if Application.fetch_env!(:nerves_runtime, :target) != "host" do
+      assert "vintage_net" in names
+      assert "vintage_net_wifi" in names
+    end
   end
 
   test "packages are alphabetized" do


### PR DESCRIPTION
Specifically these warnings:
```
You have configured application :vintage_net in your configuration file,
but the application is not available.

This usually means one of:

  1. You have not added the application as a dependency in a mix.exs file.

  2. You are configuring an application that does not really exist.

Please ensure :vintage_net exists or remove the configuration.

You have configured application :nerves_time in your configuration file,
but the application is not available.

This usually means one of:

  1. You have not added the application as a dependency in a mix.exs file.

  2. You are configuring an application that does not really exist.

Please ensure :nerves_time exists or remove the configuration.

You have configured application :mdns_lite in your configuration file,
but the application is not available.

This usually means one of:

  1. You have not added the application as a dependency in a mix.exs file.

  2. You are configuring an application that does not really exist.

Please ensure :mdns_lite exists or remove the configuration.
```

Fix the warnings by removing the no-longer needed configurations

Also fix a host test error

And fixes dialyzer warnings (albeit in a rather hacky way) by adding `Mix.target` checks throughout the code.

Based on and merges into https://github.com/livebook-dev/nerves_livebook/pull/237