### PR TITLE
Add WiFiMonitor to ensure a WiFi network is available

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -2,5 +2,6 @@
 #
 # See https://github.com/jeremyjh/dialyxir#elixir-term-format
 [
-  {"lib/nerves_livebook/fwup.ex", :no_return, 31}
+  {"lib/nerves_livebook/fwup.ex", :no_return, 31},
+  {"lib/nerves_livebook/application.ex", :pattern_match, 99}
 ]

--- a/lib/nerves_livebook/application.ex
+++ b/lib/nerves_livebook/application.ex
@@ -17,10 +17,11 @@ defmodule NervesLivebook.Application do
 
     delux_options = Application.get_env(:nerves_livebook, :delux_config, [])
 
-    children = [
-      {Delux, [name: NervesLivebook.Delux] ++ delux_options},
-      NervesLivebook.UI
-    ]
+    children =
+      [
+        {Delux, [name: NervesLivebook.Delux] ++ delux_options},
+        NervesLivebook.UI
+      ] ++ target_children(Nerves.Runtime.mix_target())
 
     Supervisor.start_link(children, opts)
   end
@@ -94,4 +95,7 @@ defmodule NervesLivebook.Application do
       :ok
     end
   end
+
+  defp target_children(:srhub), do: [NervesLivebook.WiFiMonitor]
+  defp target_children(_), do: []
 end

--- a/lib/nerves_livebook/wifi_monitor.ex
+++ b/lib/nerves_livebook/wifi_monitor.ex
@@ -1,0 +1,126 @@
+defmodule NervesLivebook.WiFiMonitor do
+  @moduledoc """
+  Monitor WiFi on startup to determine if AP mode needs to be enabled
+
+  This is mostly for devices that must have a WiFi connection in order to interact and
+  make firmware changes. It checks:
+
+  * If any WiFi interface available to configure
+  * If any WiFi interface is configured
+  * If any WiFi interface is connected
+
+  If WiFi interface is configured, but not connected, then this monitor will watch
+  for a successful connection message for 3 minutes. If no connection is established
+  after that time, then it will set the WiFi interface to AP mode to allow the user
+  to connect directly to the device
+
+  If no WiFi interface is present, then this will run until presence is detected.
+  """
+  use GenServer, restart: :transient
+
+  require Logger
+
+  @presence_prop ["interface", "wlan0", "present"]
+  @connection_prop ["interface", "wlan0", "connection"]
+  @connected_status [:lan, :internet]
+  @default_timeout 3 * 60 * 1000
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl GenServer
+  def init(opts) do
+    # These are mostly used for testing
+    state = %{
+      timeout:
+        opts[:timeout] ||
+          Application.get_env(:nerves_livebook, :wifi_monitor_timeout, @default_timeout),
+      test_fn: opts[:test_fn]
+    }
+
+    VintageNet.subscribe(@presence_prop)
+    VintageNet.subscribe(@connection_prop)
+
+    if VintageNet.get(@presence_prop) do
+      {:ok, state, {:continue, :check_connection}}
+    else
+      {:ok, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_continue(:check_connection, state) do
+    cond do
+      connected?() ->
+        stop(state)
+
+      unconfigured?() ->
+        start_ap(state)
+        stop(state)
+
+      true ->
+        {:noreply, state, state.timeout}
+    end
+  end
+
+  @impl GenServer
+  def handle_info(:timeout, state) do
+    _ = if state.test_fn, do: state.test_fn.(:timeout)
+    _ = unless connected?(), do: start_ap(state)
+
+    stop(state)
+  end
+
+  def handle_info({VintageNet, @presence_prop, _old, true, _meta}, state) do
+    # wlan0 now present so run our checks again
+    Logger.info("[WiFiMonitor] wlan0 interface present")
+    {:noreply, state, {:continue, :check_connection}}
+  end
+
+  def handle_info({VintageNet, @presence_prop, true, _new, _meta}, state) do
+    # wlan0 is gone for some reason. Matching here stops any GenServer timer so
+    # we can continue waiting for wlan0 to come back
+    Logger.warn("[WiFiMonitor] wlan0 interface gone")
+    _ = if state.test_fn, do: state.test_fn.(:continue)
+    {:noreply, state}
+  end
+
+  def handle_info({VintageNet, @connection_prop, _old, new, _meta}, state)
+      when new in @connected_status do
+    Logger.info("[WiFiMonitor] wlan0 #{IO.ANSI.green()}connected!#{IO.ANSI.default_color()}")
+    stop(state)
+  end
+
+  def handle_info({VintageNet, @connection_prop, _old, new, _meta}, state) do
+    Logger.warn("[WiFiMonitor] wlan0 connection: #{new}")
+    {:noreply, state, {:continue, :check_connection}}
+  end
+
+  defp unconfigured?() do
+    "wlan0" not in VintageNet.configured_interfaces() or
+      VintageNet.get_configuration("wlan0") == %{type: VintageNetWiFi}
+  end
+
+  defp connected?() do
+    VintageNet.get(@connection_prop) in @connected_status
+  end
+
+  defp stop(state) do
+    _ = if state.test_fn, do: state.test_fn.(:stopped)
+    {:stop, :normal, state}
+  end
+
+  if Mix.target() == :host do
+    defp start_ap(%{test_fn: test_fn}) when is_function(test_fn), do: test_fn.(:start_ap)
+    defp start_ap(_state), do: :ok
+  else
+    defp start_ap(_state) do
+      # TODO: Change some LED here to indicate AP mode?
+      {:ok, hostname} = :inet.gethostname()
+
+      {:ok, config} = VintageNetWiFi.Cookbook.open_access_point(to_string(hostname))
+
+      VintageNet.configure("wlan0", config, persist: false)
+    end
+  end
+end

--- a/test/nerves_livebook/wifi_monitor_test.exs
+++ b/test/nerves_livebook/wifi_monitor_test.exs
@@ -1,0 +1,111 @@
+defmodule NervesLivebook.WiFiMonitorTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias NervesLivebook.WiFiMonitor
+
+  @presence_prop ["interface", "wlan0", "present"]
+  @connection_prop ["interface", "wlan0", "connection"]
+  @default_config %{
+    type: VintageNetWiFi,
+    vintage_net_wifi: %{networks: [%{ssid: "test", psk: "psk"}]}
+  }
+
+  setup do
+    PropertyTable.delete(VintageNet, @presence_prop)
+    PropertyTable.delete(VintageNet, @connection_prop)
+    PropertyTable.delete(VintageNet, ["interface", "wlan0", "type"])
+    PropertyTable.delete(VintageNet, ["interface", "wlan0", "config"])
+  end
+
+  test "stops when WiFi is LAN connected and configured" do
+    PropertyTable.put(VintageNet, @presence_prop, true)
+    PropertyTable.put(VintageNet, @connection_prop, :lan)
+    start_supervised!({WiFiMonitor, [test_fn: test_fn()]})
+    assert_receive :stopped
+    refute_receive :start_ap
+  end
+
+  test "stops when WiFi is internet connected and configured" do
+    PropertyTable.put(VintageNet, @presence_prop, true)
+    PropertyTable.put(VintageNet, @connection_prop, :internet)
+    start_supervised!({WiFiMonitor, [test_fn: test_fn()]})
+    assert_receive :stopped
+    refute_receive :start_ap
+  end
+
+  test "not connected and unconfigured starts AP" do
+    PropertyTable.put(VintageNet, @presence_prop, true)
+    PropertyTable.put(VintageNet, @connection_prop, :disconnected)
+    start_supervised!({WiFiMonitor, [test_fn: test_fn()]})
+    assert_receive :start_ap
+    assert_receive :stopped
+  end
+
+  test "not connected and empty configuration starts AP" do
+    PropertyTable.put(VintageNet, @presence_prop, true)
+    PropertyTable.put(VintageNet, @connection_prop, :disconnected)
+    configure_wlan(%{type: VintageNetWiFi})
+    start_supervised!({WiFiMonitor, [test_fn: test_fn()]})
+    assert_receive :start_ap
+    assert_receive :stopped
+  end
+
+  test "not connected and configured will start AP after timeout" do
+    PropertyTable.put(VintageNet, @presence_prop, true)
+    PropertyTable.put(VintageNet, @connection_prop, :disconnected)
+    configure_wlan()
+    start_supervised!({WiFiMonitor, [test_fn: test_fn(), timeout: 1]})
+    assert_receive :timeout
+    assert_receive :stopped
+    assert_receive :start_ap
+  end
+
+  test "waits until wlan0 present to run check" do
+    PropertyTable.put(VintageNet, @presence_prop, false)
+    PropertyTable.put(VintageNet, @connection_prop, :internet)
+    configure_wlan()
+    monitor = start_supervised!({WiFiMonitor, [test_fn: test_fn()]})
+    assert Process.alive?(monitor)
+    output = capture_log(fn -> PropertyTable.put(VintageNet, @presence_prop, true) end)
+    assert_receive :stopped
+    refute_receive :start_ap
+    assert output =~ "wlan0 interface present"
+  end
+
+  test "waits until wlan0 connection to run check" do
+    PropertyTable.put(VintageNet, @presence_prop, true)
+    PropertyTable.delete(VintageNet, @connection_prop)
+    configure_wlan()
+    monitor = start_supervised!({WiFiMonitor, [test_fn: test_fn()]})
+    assert Process.alive?(monitor)
+    output = capture_log(fn -> PropertyTable.put(VintageNet, @connection_prop, :internet) end)
+    assert_receive :stopped
+    refute_receive :start_ap
+    assert output =~ ~r/wlan0.*connected/
+  end
+
+  test "removed wlan0 interface keeps monitor running" do
+    PropertyTable.put(VintageNet, @presence_prop, true)
+    PropertyTable.put(VintageNet, @connection_prop, :disconnected)
+    configure_wlan()
+    monitor = start_supervised!({WiFiMonitor, [test_fn: test_fn()]})
+    output = capture_log(fn -> PropertyTable.put(VintageNet, @presence_prop, false) end)
+    assert_receive :continue
+    refute_receive :stopped
+    assert output =~ "wlan0 interface gone"
+    assert Process.alive?(monitor)
+  end
+
+  defp test_fn() do
+    p = self()
+    fn msg -> send(p, msg) end
+  end
+
+  defp configure_wlan(config \\ @default_config) do
+    # These make the wlan0 appear as an interface and seem to be empty configuration
+    PropertyTable.put(VintageNet, ["interface", "wlan0", "type"], VintageNetWiFi)
+    PropertyTable.put(VintageNet, ["interface", "wlan0", "config"], config)
+  end
+end


### PR DESCRIPTION
This is currently only used for the `:srhub` target since it is critical that
a WiFi network is available being the only means of connection to this
specific hardware target. If it is deemed that the target has no way to
connect to a network, then it will start itself in AP mode to allow a user
to connect directly to the device