### PR TITLE
Switch LEDs to cyan since all-on is less nice

### DIFF
--- a/lib/nerves_livebook/ui.ex
+++ b/lib/nerves_livebook/ui.ex
@@ -38,7 +38,7 @@ defmodule NervesLivebook.UI do
 
   def handle_info(_, state), do: {:noreply, state}
 
-  defp led_program(:internet), do: Effects.on(:on)
-  defp led_program(:lan), do: Effects.on(:on)
-  defp led_program(_disconnected), do: Effects.blink(:on, 4)
+  defp led_program(:internet), do: Effects.on(:cyan)
+  defp led_program(:lan), do: Effects.on(:cyan)
+  defp led_program(_disconnected), do: Effects.blink(:cyan, 4)
 end


### PR DESCRIPTION
All of the devices with 1 or 2 LEDs have a green or blue one to use.

At some point, we may need to choose themes based on the device.
