### PR TITLE
Bump Elixir to 1.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
     MIX_ENV: prod
 
 elixir_version: &elixir_version
-  ELIXIR_VERSION: 1.13.4-otp-25
+  ELIXIR_VERSION: 1.14.0-otp-25
 
 install_elixir: &install_elixir
   run:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 25.0.3
-elixir 1.13.4-otp-25
+erlang 25.0.4
+elixir 1.14.0-otp-25


### PR DESCRIPTION
This reports a warning when building since `nerves` is forced to an
earlier version, but this warning isn't a real problem.
