### PR TITLE
Fix hyperlinks

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -53,7 +53,10 @@ config :livebook, :learn_notebooks, [
       cover_path: "#{File.cwd!()}/assets/wifi-setup.svg",
       description: "Connect Nerves Livebook to a wireless network."
     }
-  }
+  },
+  %{path: "#{File.cwd!()}/priv/samples/basics/sys_class_leds.livemd", details: nil},
+  %{path: "#{File.cwd!()}/priv/samples/networking/firmware_update.livemd", details: nil},
+  %{path: "#{File.cwd!()}/priv/samples/networking/vintage_net.livemd", details: nil}
 ]
 
 # Enable the embedded runtime which isn't available by default

--- a/priv/samples/networking/configure_wifi.livemd
+++ b/priv/samples/networking/configure_wifi.livemd
@@ -62,4 +62,4 @@ VintageNet.info()
 
 ## Next up...
 
-See [VintageNet](vintage_net.livemd) to learn more about networking in Nerves.
+See [VintageNet](/learn/notebooks/vintage-net) to learn more about networking in Nerves.

--- a/priv/welcome.livemd
+++ b/priv/welcome.livemd
@@ -21,10 +21,10 @@ all read-only so you'll need to *fork* them just like you did to open this
 file. Livebook and Nerves Livebook are rapidly evolving so some notebooks are a
 work-in-progress. We recommend starting with the following:
 
-* [Configure WiFi](samples/networking/configure_wifi.livemd) - connect to a WiFi access point
-* [LEDs](samples/basics/sys_class_leds.livemd) - learn about the built-in LEDs on your device
-* [VintageNet](samples/networking/vintage_net.livemd) - learn about networking on Nerves devices
-* [Firmware Update](samples/networking/firmware_update.livemd) - download the latest Nerves Livebook firmware
+* [Configure WiFi](/learn/notebooks/wifi) - connect to a WiFi access point
+* [LEDs](/learn/notebooks/sys-class-leds) - learn about the built-in LEDs on your device
+* [VintageNet](/learn/notebooks/vintage-net) - learn about networking on Nerves devices
+* [Firmware Update](/learn/notebooks/firmware-update) - download the latest Nerves Livebook firmware
 
 ## Saving and copying files
 


### PR DESCRIPTION
### Description

Currently hyperlinks between notebooks are not working. It is because Livebook is particular about the way it handles notebooks.

Here is what to do:
1. Be sure that we register our custom notebooks
    - `config :livebook, :learn_notebooks, []`
    - either when we want to show a notebook in Learn section or when we want to hyperlink
    - pass `details: nil` when we want to hide a notebook in the Learn section
1. Hyperlink has to be `/learn/notebooks/<slug>`
    - the slug is either user-specified or inferred by Livebook base on the file name
    - E.g., `/learn/notebooks/vintage-net`

### Changes

- 