### PR TITLE
Update srhub config for delux indicator settings

### DIFF
--- a/config/srhub.exs
+++ b/config/srhub.exs
@@ -6,5 +6,4 @@ config :vintage_net,
   config: [{"wlan0", %{type: VintageNetWiFi}}]
 
 # Srhubs have a red/green LED
-config :nerves_livebook, :delux_config,
-  indicators: %{default: %{red: "led1:red", green: "led1:green"}}
+config :delux, indicators: %{default: %{red: "led1:red", green: "led1:green"}}


### PR DESCRIPTION
To match the rest of the available targets. This is confirmed to set the LEDs to green once it's on wifi.