### PR TITLE
Add flash_livebook.sh to automate Livebook firmware flashing

### DIFF
--- a/guides/quickstart.md
+++ b/guides/quickstart.md
@@ -1,0 +1,107 @@
+# Quickstart: Flash Nerves Livebook
+
+This guide shows you how to download and flash the latest Nerves Livebook
+firmware in one simple flow. By the end, you’ll have Livebook running on your
+device and be ready to explore tutorials in your browser.
+
+---
+
+## Prerequisites
+
+1. A supported board (Raspberry Pi Zero/Zero W, Pi 4, BeagleBone Black, etc.)
+2. A micro‑SD card and an SD‑card reader (built‑in slot or USB adapter)
+3. On your host machine:
+   - bash (4+)
+   - curl
+   - fwup (requires `sudo`; see https://github.com/fwup-home/fwup)
+
+---
+
+## Clone the repository
+
+```bash
+git clone https://github.com/nerves-livebook/nerves_livebook.git
+cd nerves_livebook
+```
+
+---
+
+## Flash with one command
+
+Make the helper script executable:
+
+```bash
+chmod +x scripts/flash_livebook.sh
+```
+
+Then run:
+
+```bash
+./scripts/flash_livebook.sh
+```
+
+You will be prompted to:
+
+- Select your `MIX_TARGET` (e.g. `rpi0`, `rpi4`, `bbb`)
+- Enter WiFi SSID and passphrase
+- Optionally set a custom serial number
+- Insert your SD card when asked
+
+The script will download the latest `.fw`, provision it, wait for your card,
+and invoke `sudo fwup …` for you.
+
+> #### Single‑command installer
+>
+> You can also run it directly from your shell in one step:
+>
+> ```bash
+> bash <(curl -fsSL https://raw.githubusercontent.com/nerves-livebook/nerves_livebook/main/scripts/flash_livebook.sh)
+> ```
+
+---
+
+## Verify Livebook
+
+1. Eject the SD card and insert it into your board
+2. Power on and connect to your network
+3. Open http://nerves.local in your browser
+4. Log in with password: nerves
+
+You should see the Livebook home page and built‑in tutorials.
+
+---
+
+## Next steps
+
+### Explore the built‑in tutorials
+
+Click any example notebook. Run the code cells to see hardware I/O, GPIO
+examples, and more—no additional setup required.
+
+### Build your own firmware
+
+1. Create a new project skeleton:
+   ```bash
+   mix nerves.new my_nerves_app
+   cd my_nerves_app
+   ```
+2. Open `lib/my_nerves_app.ex` in your editor and tweak the example (e.g. blink an LED).
+3. Fetch deps and compile:
+   ```bash
+   mix deps.get
+   mix firmware
+   ```
+4. Generate an upload script:
+   ```bash
+   mix firmware.gen.script
+   ```
+
+### Deploy Over‑the‑Air
+
+With your board on the network, run:
+
+```bash
+./upload.sh nerves.local
+```
+
+This sends your newly built firmware straight to the device—no SD card required.

--- a/guides/quickstart.md
+++ b/guides/quickstart.md
@@ -6,6 +6,28 @@ device and be ready to explore tutorials in your browser.
 
 ---
 
+## Evaluate in seconds
+
+Run this single command to download, provision, and flash the latest firmware:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/nerves-livebook/nerves_livebook/main/scripts/flash_livebook.sh)
+```
+
+You’ll be prompted to:
+
+- Select your `MIX_TARGET` (e.g. `rpi0`, `rpi4`, `bbb`)
+- Enter WiFi SSID & passphrase
+- Optionally set a custom serial number
+- Insert your SD card when asked
+
+This one-liner installer fetches and runs the flashing helper, cleans up after
+itself, and leaves you with a ready-to-go Livebook card. If you’d like to review
+or customize the script first, continue by cloning the repository in the next
+section.
+
+---
+
 ## Prerequisites
 
 1. A supported board (Raspberry Pi Zero/Zero W, Pi 4, BeagleBone Black, etc.)
@@ -19,10 +41,16 @@ device and be ready to explore tutorials in your browser.
 
 ## Clone the repository
 
+If you want to inspect or tweak the flashing script before running it, clone
+the repo:
+
 ```bash
 git clone https://github.com/nerves-livebook/nerves_livebook.git
 cd nerves_livebook
 ```
+
+By cloning, you can open `scripts/flash_livebook.sh` in your editor, make any
+adjustments or integrations, and then execute it locally.
 
 ---
 
@@ -49,14 +77,6 @@ You will be prompted to:
 
 The script will download the latest `.fw`, provision it, wait for your card,
 and invoke `sudo fwup …` for you.
-
-> #### Single‑command installer
->
-> You can also run it directly from your shell in one step:
->
-> ```bash
-> bash <(curl -fsSL https://raw.githubusercontent.com/nerves-livebook/nerves_livebook/main/scripts/flash_livebook.sh)
-> ```
 
 ---
 

--- a/guides/quickstart.md
+++ b/guides/quickstart.md
@@ -6,6 +6,17 @@ device and be ready to explore tutorials in your browser.
 
 ---
 
+## Prerequisites
+
+1. A supported board (Raspberry Pi Zero/Zero W, Pi 4, BeagleBone Black, etc.)
+2. A micro‑SD card and an SD‑card reader (built‑in slot or USB adapter)
+3. On your host machine:
+  - bash (4+)
+  - curl
+  - fwup (requires `sudo`; see https://github.com/fwup-home/fwup)
+
+---
+
 ## Evaluate in seconds
 
 Run this single command to download, provision, and flash the latest firmware:
@@ -25,17 +36,6 @@ This one-liner installer fetches and runs the flashing helper, cleans up after
 itself, and leaves you with a ready-to-go Livebook card. If you’d like to review
 or customize the script first, continue by cloning the repository in the next
 section.
-
----
-
-## Prerequisites
-
-1. A supported board (Raspberry Pi Zero/Zero W, Pi 4, BeagleBone Black, etc.)
-2. A micro‑SD card and an SD‑card reader (built‑in slot or USB adapter)
-3. On your host machine:
-   - bash (4+)
-   - curl
-   - fwup (requires `sudo`; see https://github.com/fwup-home/fwup)
 
 ---
 

--- a/scripts/flash_livebook.sh
+++ b/scripts/flash_livebook.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+#
+# Download & flash Nerves Livebook firmware.
+# Run with -h or --help for usage and options.
+#
+set -euo pipefail
+
+help_text() {
+  cat <<EOF
+Usage: $(basename "$0") [--help|-h]
+
+A tiny helper to download and flash the latest Nerves Livebook firmware.
+
+Options:
+  -h, --help    Show this help message and exit
+
+Environment variables:
+  MIX_TARGET             target platform (rpi, rpi0, rpi4, bbb, etc.)
+  NERVES_WIFI_SSID       WiFi SSID for provisioning (quote if spaces)
+  NERVES_WIFI_PASSPHRASE WiFi passphrase (quote if spaces)
+  NERVES_WIFI_FORCE      set WiFi every boot ("true")
+  NERVES_SERIAL_NUMBER   custom device serial number
+
+Prerequisites:
+  • bash (4+), curl, fwup (requires sudo)
+    See: https://github.com/fwup-home/fwup
+
+Resources:
+  • Nerves Livebook repo: https://github.com/nerves-livebook/nerves_livebook
+EOF
+}
+
+echo_heading() {
+  printf "\n\033[34m%s\033[0m\n" "$1"
+}
+
+echo_success() {
+  printf " \033[32m✔ %s\033[0m\n" "$1"
+}
+
+echo_error() {
+  printf " \033[31m✖ %s\033[0m\n" "$1"
+}
+
+ensure_fwup() {
+  if ! command -v fwup >/dev/null 2>&1; then
+    echo_error "fwup is not installed. Please install it (e.g. via your package manager) and re‑run."
+    exit 1
+  fi
+  echo_success "fwup is installed"
+}
+
+ensure_curl() {
+  if ! command -v curl >/dev/null 2>&1; then
+    echo_error "curl is not installed. Please install it and re‑run."
+    exit 1
+  fi
+  echo_success "curl is installed"
+}
+
+select_mix_target() {
+  if [ -n "${MIX_TARGET-}" ]; then
+    echo_success "Using MIX_TARGET from env: ${MIX_TARGET}"
+  else
+    echo_heading "Select MIX_TARGET"
+    local targets=(
+      rpi rpi0 rpi2 rpi3a rpi3 rpi4 rpi5
+      bbb x86_64 osd32mp1 grisp2 mangopi_mq_pro
+      custom
+    )
+    PS3="Enter number: "
+    select tgt in "${targets[@]}"; do
+      if [ -n "$tgt" ]; then
+        MIX_TARGET=$tgt
+        break
+      fi
+    done
+
+    if [ "$MIX_TARGET" = custom ]; then
+      read -rp "Custom MIX_TARGET: " MIX_TARGET
+    fi
+
+    echo_success "→ MIX_TARGET=${MIX_TARGET}"
+  fi
+}
+
+download_firmware() {
+  echo_heading "Downloading firmware for ${MIX_TARGET}"
+  local url="https://github.com/nerves-livebook/nerves_livebook/releases/latest/download/nerves_livebook_${MIX_TARGET}.fw"
+  FW_IMAGE="$TMPDIR/nerves_livebook_${MIX_TARGET}.fw"
+  if ! curl -fsSL "$url" -o "$FW_IMAGE"; then
+    echo_error "Failed downloading ${url}"
+    exit 1
+  fi
+  echo_success "Saved to ${FW_IMAGE}"
+}
+
+configure_provisioning() {
+  echo_heading "Configuring provisioning options"
+  PROVISIONING_ENV=()
+
+  if [ -n "${NERVES_WIFI_SSID-}" ]; then
+    echo_success "SSID from env: ${NERVES_WIFI_SSID}"
+    PROVISIONING_ENV+=("NERVES_WIFI_SSID=${NERVES_WIFI_SSID}")
+  else
+    read -rp "WiFi SSID (blank to skip): " ssid
+    if [ -n "$ssid" ]; then
+      PROVISIONING_ENV+=("NERVES_WIFI_SSID=${ssid}")
+    fi
+  fi
+
+  if [ -n "${NERVES_WIFI_PASSPHRASE-}" ]; then
+    echo_success "Passphrase from env"
+    PROVISIONING_ENV+=("NERVES_WIFI_PASSPHRASE=${NERVES_WIFI_PASSPHRASE}")
+  else
+    read -rp "WiFi passphrase (blank to skip): " psk
+    if [ -n "$psk" ]; then
+      PROVISIONING_ENV+=("NERVES_WIFI_PASSPHRASE=${psk}")
+    fi
+  fi
+
+  read -rp "Force WiFi each boot? [y/N]: " wifi_force_answer
+  case "$wifi_force_answer" in
+  [Yy]*)
+    PROVISIONING_ENV+=("NERVES_WIFI_FORCE=true")
+    ;;
+  *) ;;
+  esac
+
+  if [ -n "${NERVES_SERIAL_NUMBER-}" ]; then
+    echo_success "Serial from env: ${NERVES_SERIAL_NUMBER}"
+    PROVISIONING_ENV+=("NERVES_SERIAL_NUMBER=${NERVES_SERIAL_NUMBER}")
+  else
+    read -rp "Custom serial# (blank for default): " serial_answer
+    if [ -n "$serial_answer" ]; then
+      PROVISIONING_ENV+=("NERVES_SERIAL_NUMBER=${serial_answer}")
+    fi
+  fi
+
+  echo_success "Provisioning environment prepared"
+}
+
+flash_card() {
+  echo_heading "Ready to flash Nerves Livebook"
+  echo "→ Firmware file : $(basename "$FW_IMAGE")"
+  echo "→ File path     : $FW_IMAGE"
+
+  local auto_dev=""
+  until auto_dev=$(fwup -z 2>/dev/null); do
+    echo_error "fwup did not detect any removable device."
+    read -rp "Please insert your SD card or USB adapter, then press Enter to retry..."
+  done
+
+  echo_success "fwup will target: ${auto_dev}"
+
+  read -rp "Proceed to flash this firmware? [y/N]: " proceed_answer
+  case "$proceed_answer" in
+  [Yy]*)
+    echo_heading "Launching fwup"
+    sudo "${PROVISIONING_ENV[@]}" fwup "$FW_IMAGE"
+    echo_success "Your Nerves Livebook card is ready!"
+    echo
+    echo "Next steps:"
+    echo "  1. Eject, insert into your device."
+    echo "  2. Power on and ensure network connectivity."
+    echo "  3. Visit http://nerves.local (password: nerves)."
+    ;;
+  *)
+    echo_error "Aborted by user"
+    exit 1
+    ;;
+  esac
+}
+
+main() {
+  case "${1:-}" in
+  -h | --help)
+    help_text
+    exit 0
+    ;;
+  "") ;;
+  *)
+    echo_error "Unknown option: $1"
+    help_text
+    exit 1
+    ;;
+  esac
+
+  TMPDIR=$(mktemp -d)
+  trap 'echo_success "Removing temporary directory: $TMPDIR"; rm -rf "$TMPDIR"' EXIT
+
+  ensure_fwup
+  ensure_curl
+  select_mix_target
+  download_firmware
+  configure_provisioning
+  flash_card
+}
+
+main "$@"

--- a/scripts/flash_livebook.sh
+++ b/scripts/flash_livebook.sh
@@ -66,7 +66,6 @@ select_mix_target() {
     local targets=(
       rpi rpi0 rpi2 rpi3a rpi3 rpi4 rpi5
       bbb x86_64 osd32mp1 grisp2 mangopi_mq_pro
-      custom
     )
     PS3="Enter number: "
     select tgt in "${targets[@]}"; do
@@ -75,10 +74,6 @@ select_mix_target() {
         break
       fi
     done
-
-    if [ "$MIX_TARGET" = custom ]; then
-      read -rp "Custom MIX_TARGET: " MIX_TARGET
-    fi
 
     echo_success "→ MIX_TARGET=${MIX_TARGET}"
   fi


### PR DESCRIPTION
## Description

Add `scripts/flash_livebook.sh`, a lightweight shell wrapper that automates the entire process of fetching, provisioning, and flashing the latest Nerves Livebook firmware onto an SD card. It validates prerequisites (`bash`, `curl`, `fwup`), provides a `-h|--help` usage guide, and cleans up its temporary download directory on exit.

## Motivation

Getting started with Nerves Livebook currently requires manually downloading the correct `.fw` for your `MIX_TARGET`, entering provisioning options, and burning the image via `fwup` or Etcher. This script consolidates those steps into a single, self‑documented command, lowering the barrier for newcomers and speeding up iterative demos.

## Usage

```bash
# Fully interactive run:
./scripts/flash_livebook.sh

# Pre‑set provisioning to skip prompts:
export MIX_TARGET=rpi4
export NERVES_WIFI_SSID="MySSID"
export NERVES_WIFI_PASSPHRASE="MyPass"
export NERVES_SERIAL_NUMBER="pi-42"
./scripts/flash_livebook.sh
```

By exporting those variables, you skip the corresponding prompts—only SD‑card detection and final confirmation remain interactive.

![image](https://github.com/user-attachments/assets/fb31c59c-8415-4c86-99ce-d5b062621875)

![image](https://github.com/user-attachments/assets/a67f6514-4756-40e8-8b5b-d3547c50ea42)
