### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ over a USB cable:
 ## Going further
 
 At some point you may want to customize Nerves Livebook. See the [Nerves
-Installation](https://hexdocs.pm/nerves/installation.html) and [Getting
-Started](https://hexdocs.pm/nerves/getting-started.html) guides for details.
+Installation](https://nerves.hexdocs.pm/installation.html) and [Getting
+Started](https://nerves.hexdocs.pm/getting-started.html) guides for details.
 
 To build the Nerves Livebook firmware, make sure that you have run through the
 Nerves installation steps. Then open a terminal window and run the following:

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,7 +4,7 @@ import Config
 Application.start(:nerves_bootstrap)
 
 # Customize non-Elixir parts of the firmware. See
-# https://hexdocs.pm/nerves/advanced-configuration.html for details.
+# https://nerves.hexdocs.pm/advanced-configuration.html for details.
 
 config :nerves, :firmware,
   rootfs_overlay: "rootfs_overlay",

--- a/config/target.exs
+++ b/config/target.exs
@@ -14,7 +14,7 @@ config :shoehorn, init: [:nerves_runtime, :nerves_pack]
 config :nerves_runtime, startup_guard_enabled: true
 
 # Use Ringlogger as the logger backend and remove :console.
-# See https://hexdocs.pm/ring_logger/readme.html for more information on
+# See https://ring-logger.hexdocs.pm/readme.html for more information on
 # configuring ring_logger.
 
 config :logger, backends: [RingLogger, RamoopsLogger]
@@ -32,8 +32,8 @@ config :nerves, :erlinit, update_clock: true
 
 # Configure the device for SSH IEx prompt access and firmware updates
 #
-# * See https://hexdocs.pm/nerves_ssh/readme.html for general SSH configuration
-# * See https://hexdocs.pm/ssh_subsystem_fwup/readme.html for firmware updates
+# * See https://nerves-ssh.hexdocs.pm/readme.html for general SSH configuration
+# * See https://ssh-subsystem-fwup.hexdocs.pm/readme.html for firmware updates
 
 config :nerves_ssh,
   daemon_option_overrides: [

--- a/lib/nerves_livebook/application.ex
+++ b/lib/nerves_livebook/application.ex
@@ -1,5 +1,5 @@
 defmodule NervesLivebook.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -12,7 +12,7 @@ defmodule NervesLivebook.Application do
     setup_wifi()
     add_mix_install()
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: NervesLivebook.Supervisor]
 
@@ -106,7 +106,7 @@ defmodule NervesLivebook.Application do
     defp target_children(_), do: []
 
     defp advertise_device() do
-      # See https://hexdocs.pm/nerves_discovery/
+      # See https://nerves-discovery.hexdocs.pm/
       MdnsLite.add_mdns_service(%{
         id: :nerves_device,
         protocol: "nerves-device",


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://nerves.hexdocs.pm/installation.html): Status 301
❌ Verification failed for https://nerves.hexdocs.pm/getting-started.html): Status 301
⚠️ Verification finished: 7 success, 2 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>